### PR TITLE
replace deprecated open_api method with GitHub::API.open_rest

### DIFF
--- a/custom_download_strategy.rb
+++ b/custom_download_strategy.rb
@@ -101,6 +101,6 @@ class GitHubPrivateRepositoryReleaseDownloadStrategy < GitHubPrivateRepositoryDo
 
   def fetch_release_metadata
     release_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
-    GitHub.open_api(release_url)
+    GitHub::API.open_rest(release_url)
   end
 end


### PR DESCRIPTION
Fixes the following message

```
==> Downloading https://github.com/planetscale/cli/releases/download/v0.2.1/pscale_0.2.1_macOS_amd64.tar.gz
Warning: Calling GitHub.open_api is deprecated! Use GitHub::API.open_rest instead.
Please report this issue to the planetscale/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/planetscale/homebrew-tap/custom_download_strategy.rb:104
```
