### PR TITLE
Usage of 'bottle: unneeded' has been deprecated

### DIFF
--- a/Formula/pscale-proxy.rb
+++ b/Formula/pscale-proxy.rb
@@ -7,7 +7,6 @@ class PscaleProxy < Formula
   homepage "https://planetscale.com/"
   version "0.11.0"
   license "Apache 2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/Formula/pscale.rb
+++ b/Formula/pscale.rb
@@ -7,7 +7,6 @@ class Pscale < Formula
   homepage "https://planetscale.com/"
   version "0.82.0"
   license "Apache 2.0"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
See: https://github.com/Homebrew/homebrew-core/issues/75943

When upgrading homebrew you see this:
```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the planetscale/tap tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/planetscale/homebrew-tap/Formula/pscale.rb:10
```

Signed-off-by: Matt Lord <mattalord@gmail.com>